### PR TITLE
CMakeLists.txt : add boost includes and static libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ggdb -Og")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ggdb -Og")
 find_package(SDL2 REQUIRED)
+set(Boost_USE_STATIC_LIBS ON)
+find_package(Boost REQUIRED)
 
-include_directories(${CMAKE_CURRENT_LIST_DIR} include/ Musashi/ external/ ${SDL2_INCLUDE_DIRS})
+include_directories(${CMAKE_CURRENT_LIST_DIR} include/ Musashi/ external/ ${SDL2_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
 add_executable(sq68ux
     src/q68_main.cpp
@@ -23,11 +25,11 @@ add_executable(sq68ux
     Musashi/softfloat/softfloat.c
     )
 
-if (SDL2_LIBRARIES)
+if (SDL2_LIBRARIES AND Boost_FOUND)
     if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
         target_link_libraries(sq68ux -Wl,-Bstatic -L/usr/local/x86_64-w64-mingw32/lib -lSDL2main -lSDL2 -Wl,-Bdynamic -lwsock32 -lwinmm -lsetupapi -limm32 -lversion -static-libgcc)
     else()
-        target_link_libraries(sq68ux ${SDL2_LIBRARIES})
+        target_link_libraries(sq68ux ${SDL2_LIBRARIES} ${Boost_LIBRARIES})
     endif()
 else()
     target_link_libraries(sq68ux SDL2::SDL2)


### PR DESCRIPTION
Add boost includes and static version of boost libraries.

N.B. So far only Boost::endian is in use and it's a header-only library so no actual .a:s are linked!

No changes to Windows build since I don't have a Win environment suitable for testing.